### PR TITLE
Implements more robust approach to building web url on image upload

### DIFF
--- a/plugins/ilimgupload/imgupload.php
+++ b/plugins/ilimgupload/imgupload.php
@@ -39,7 +39,10 @@ $lng->loadLanguageModule('form');
 $htdocs = $ilIliasIniFile->readVariable('server', 'absolute_path') . '/';
 $weburl = $ilIliasIniFile->readVariable('server', 'absolute_path') . '/';
 if (defined('ILIAS_HTTP_PATH')) {
-    $weburl = substr(ILIAS_HTTP_PATH, 0, strrpos(ILIAS_HTTP_PATH, '/node_modules')) . '/';
+    $weburl = ILIAS_HTTP_PATH . '/';
+    if (str_contains(ILIAS_HTTP_PATH, '/node_modules')) {
+        $weburl = substr(ILIAS_HTTP_PATH, 0, strrpos(ILIAS_HTTP_PATH, '/node_modules')) . '/';
+    }
 }
 
 $installpath = $htdocs;


### PR DESCRIPTION
In some cases, though not reliably reproducible, we observed that the constant `ILIAS_HTTP_PATH` does not contain the expected string `/node_modules`. This results in an error because `strrpos` returns false, which is then passed to the `substr` function. Since `substr` expects an integer as the third parameter, this causes a type error and prevents image uploads inside the editor.

By first checking whether the constant contains the expected string and skipping the `substr` call if it does not, we can avoid this issue. This safeguard does not interfere with the correct functioning of the code in any cases.